### PR TITLE
Update to secure favicon request

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <title>Rice Thresher Purity Test</title>
         
         <!-- Favicon -->
-        <link rel="icon" type="image/png" href="http://d2jz71s5ipgn8z.cloudfront.net/20160524mylhvToIpZ/dist/img/favicons/apple-touch-icon-60x60.png">
+        <link rel="icon" type="image/png" href="https://d2jz71s5ipgn8z.cloudfront.net/20160524mylhvToIpZ/dist/img/favicons/apple-touch-icon-60x60.png">
 
 
         <!-- Style -->


### PR DESCRIPTION
with security updates to browsers, most no longer or will not allow "mixed content" (in this case requesting icons over http vs https), chrome is one of such browsers currently disallowing this and is currently blocking the request.